### PR TITLE
Force rerenders when using setQueryParam setters

### DIFF
--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -31,6 +31,8 @@ export const useQueryParam = <D, D2 = D>(
 ): [D2 | undefined, (newValue: D, updateType?: UrlUpdateType) => void] => {
   const { history, location } = React.useContext(QueryParamContext);
 
+  const [savedParam, setSavedParam] = React.useState();
+
   // read in the raw query
   if (!rawQuery) {
     rawQuery = React.useMemo(() => parseQueryString(location.search) || {}, [
@@ -69,8 +71,9 @@ export const useQueryParam = <D, D2 = D>(
         history,
         updateType
       );
+      setSavedParam(newEncodedValue);
     },
-    [location]
+    [location, savedParam]
   );
 
   return [decodedValue, setValue];

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -19,6 +19,7 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
   paramConfigMap: QPCMap
 ): [DecodedValueMap<QPCMap>, SetQuery<QPCMap>] => {
   const { history, location } = React.useContext(QueryParamContext);
+  const [savedQueryParams, setSavedQueryParams] = React.useState();
 
   // read in the raw query
   const rawQuery = React.useMemo(
@@ -48,6 +49,7 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
 
       // update the URL
       updateUrlQuery(encodedChanges, location, history, updateType);
+      setSavedQueryParams(encodedChanges);
     },
     [location]
   );


### PR DESCRIPTION
Currently this lib doesn't work as I would expect a hook to work. When the param is changed, a rerender is not fired. 
This fixes this by using a basically redundant useState hook to ensure a rerender happens when this changes