### PR TITLE
Persistent object if values are not changed in useQueryParams

### DIFF
--- a/src/__tests__/useQueryParams-test.tsx
+++ b/src/__tests__/useQueryParams-test.tsx
@@ -79,4 +79,18 @@ describe('useQueryParams', () => {
       baz: 'a,b', // ['a,'b'] as string = "a,b"
     });
   });
+
+  it('return persistent value if search not changed', () => {
+    const { wrapper, history } = setupWrapper({ foo: '123', bar: 'xxx' });
+    const { result, rerender } = renderHook(
+      () => useQueryParams({ foo: NumberParam, bar: StringParam }),
+      {
+        wrapper,
+      }
+    );
+    const [decodedQuery1] = result.current;
+    rerender();
+    const [decodedQuery2] = result.current;
+    expect(decodedQuery1 === decodedQuery2).toBe(true);
+  })
 });

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -28,14 +28,17 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
 
   // parse each parameter via usQueryParam
   const paramNames = Object.keys(paramConfigMap);
-  const decodedValues: Partial<DecodedValueMap<QPCMap>> = {};
-  for (const paramName of paramNames) {
-    decodedValues[paramName] = useQueryParam(
-      paramName,
-      paramConfigMap[paramName],
-      rawQuery
-    )[0];
-  }
+
+  const paramValues = paramNames.map((paramName) => useQueryParam(
+    paramName,
+    paramConfigMap[paramName],
+    rawQuery
+  )[0]);
+
+  const decodedValues = React.useMemo(() => paramNames.reduce<Partial<DecodedValueMap<QPCMap>>>((result, paramName, i) => {
+    result[paramName] = paramValues[i];
+    return result;
+  }, {}), paramValues)
 
   // create a setter for updating multiple query params at once
   const setQuery = React.useCallback(


### PR DESCRIPTION
It's helpful to write code like
```javascript
const [query, setQuery] = useQueryParams({
  // ...
});
useEffect(() => {
  fetchSomething(query);
// users have no use for listing all params here.
}, [query]);
```