### PR TITLE
Fix breaking SSR builds: check for types (#13)

### DIFF
--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -41,7 +41,7 @@ export const useQueryParam = <D, D2 = D>(
       if (typeof location === 'object' && typeof window !== undefined) {
         pathname = parseQueryString(location.search)
       } else if (typeof location === 'object') {
-        pathname = parseQueryURL(location.pathname)
+        pathname = parseQueryURL(location.pathname).query
       }
 
       return pathname

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   parse as parseQueryString,
+  parseUrl as parseQueryURL,
   stringify,
   EncodedQueryWithNulls,
   StringParam,
@@ -9,6 +10,7 @@ import {
 import { QueryParamContext } from './QueryParamProvider';
 import { updateUrlQuery } from './updateUrlQuery';
 import { UrlUpdateType } from './types';
+import { type } from 'os';
 
 /**
  * Given a query param name and query parameter configuration ({ encode, decode })
@@ -33,9 +35,17 @@ export const useQueryParam = <D, D2 = D>(
 
   // read in the raw query
   if (!rawQuery) {
-    rawQuery = React.useMemo(() => parseQueryString(location.search) || {}, [
-      location.search,
-    ]);
+    rawQuery = React.useMemo(() => {
+      let pathname = {}
+
+      if (typeof location === 'object' && typeof window !== undefined) {
+        pathname = parseQueryString(location.search)
+      } else if (typeof location === 'object') {
+        pathname = parseQueryURL(location.pathname)
+      }
+
+      return pathname
+    }, [])
   }
 
   // read in the encoded string value
@@ -53,10 +63,10 @@ export const useQueryParam = <D, D2 = D>(
     // value may be an array that is recreated if a different query param
     // changes.
   }, [
-    encodedValue instanceof Array
-      ? stringify({ name: encodedValue })
-      : encodedValue,
-  ]);
+      encodedValue instanceof Array
+        ? stringify({ name: encodedValue })
+        : encodedValue,
+    ]);
 
   // create the setter, memoizing via useCallback
   const setValue = React.useCallback(

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -10,7 +10,6 @@ import {
 import { QueryParamContext } from './QueryParamProvider';
 import { updateUrlQuery } from './updateUrlQuery';
 import { UrlUpdateType } from './types';
-import { type } from 'os';
 
 /**
  * Given a query param name and query parameter configuration ({ encode, decode })
@@ -37,13 +36,13 @@ export const useQueryParam = <D, D2 = D>(
     rawQuery = React.useMemo(() => {
       let pathname = {}
 
-      if (typeof location === 'object' && typeof window !== undefined) {
+      if (typeof location === 'object' && typeof window !== 'undefined') {
         pathname = parseQueryString(location.search)
       } else if (typeof location === 'object') {
         pathname = parseQueryURL(location.pathname).query
       }
 
-      return parseQueryString(location.search) || {}
+      return pathname || {}
     }, [location.search, location.pathname])
   }
 

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -33,7 +33,6 @@ export const useQueryParam = <D, D2 = D>(
 ): [D2 | undefined, (newValue: D, updateType?: UrlUpdateType) => void] => {
   const { history, location } = React.useContext(QueryParamContext);
 
-  // read in the raw query
   if (!rawQuery) {
     rawQuery = React.useMemo(() => {
       let pathname = {}
@@ -44,8 +43,8 @@ export const useQueryParam = <D, D2 = D>(
         pathname = parseQueryURL(location.pathname).query
       }
 
-      return pathname
-    }, [])
+      return parseQueryString(location.search) || {}
+    }, [location.search, location.pathname])
   }
 
   // read in the encoded string value


### PR DESCRIPTION
I've implemented a simple fix for a bug that caused SSR builds to break due to undefined `location`/`window`.