### PR TITLE
Fix SSR build error in useQueryParams

### DIFF
--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -39,6 +39,7 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
   paramConfigMap: QPCMap
 ): [DecodedValueMap<QPCMap>, SetQuery<QPCMap>] => {
   const { history, location } = React.useContext(QueryParamContext);
+  const locationIsObject = typeof location === 'object';
 
   // memoize paramConfigMap to make the API nicer for consumers.
   // otherwise we'd have to useQueryParams(useMemo(() => { foo: NumberParam }, []))
@@ -62,11 +63,12 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
     refLocation.current = location;
   }, [location]);
 
+  const search = locationIsObject ? location.search : '';
+
   // read in the raw query
-  const rawQuery = React.useMemo(
-    () => parseQueryString(location.search) || {},
-    [location.search]
-  );
+  const rawQuery = React.useMemo(() => parseQueryString(search) || {}, [
+    search,
+  ]);
 
   // parse each parameter via useQueryParam
   // we reuse the logic to not recreate objects


### PR DESCRIPTION
I use this module with Gatsby.
And there is an error shows while executing `gatsby build`

```
  49 |     }, [location]);
  50 |     // read in the raw query
> 51 |     var rawQuery = React.useMemo(function () { return (locationIsObject && parseQueryString(location.search)) || {}; }, [location.search]);
     |                                                                                                                       ^
  52 |     // parse each parameter via useQueryParam
  53 |     // we reuse the logic to not recreate objects
  54 |     var paramNames = Object.keys(paramConfigMap);


  WebpackError: TypeError: Cannot read property 'search' of undefined

  - useQueryParams.js:51 useQueryParams
    node_modules/@othree/use-query-params/esm/useQueryParams.js:51:119
```

This PR fixed this issue.

PS. #25 only fix the `useQueryParam` hook. This issue is in `useQueryParams`.