### PR TITLE
Fix initial params in SSR

### DIFF
--- a/src/__tests__/useQueryParam-SSR-test.tsx
+++ b/src/__tests__/useQueryParam-SSR-test.tsx
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment node
+ */
+import * as React from 'react';
+import { useQueryParam } from '../useQueryParam';
+import { renderToString } from 'react-dom/server';
+import QueryParamProvider from '../QueryParamProvider';
+import { makeMockLocation } from './helpers';
+
+test('SSR initial query param', () => {
+  const Component = () => {
+    const [foo] = useQueryParam('foo');
+
+    return <div>{foo}</div>;
+  };
+
+  const location = makeMockLocation({ foo: 'bar' });
+
+  const result = renderToString(
+    <QueryParamProvider location={location}>
+      <Component />
+    </QueryParamProvider>
+  );
+
+  expect(result).toMatchInlineSnapshot(`"<div>bar</div>"`);
+});

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -58,7 +58,12 @@ export const useQueryParam = <D, D2 = D>(
           pathname = parseQueryString(location.search);
         } else {
           // not in browser
-          pathname = parseQueryURL(location.pathname).query;
+          let url = location.pathname;
+          if (location.search) {
+            url += location.search;
+          }
+
+          pathname = parseQueryURL(url).query;
         }
       }
 


### PR DESCRIPTION
I added `location.search` to SSR query param parsing, as they didn't seem to be picked up anymore.

It's appended defensively to `location.pathname`, because I don't know the circumstances when the path is not including the query string in `location.search` (for me it does with express)

I needed to create a new file for the test (`useQueryParam-SSR-test.tsx`) to simulate a node environment with the [docblock pragma](https://jestjs.io/docs/en/configuration#testenvironment-string)

Should fix #51 

Thanks 🙏