### PR TITLE
Fix concurent updates when using React Router. 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type UrlUpdateType = 'replace' | 'replaceIn' | 'push' | 'pushIn';
 export interface PushReplaceHistory {
   push: (location: Location) => void;
   replace: (location: Location) => void;
+  location?: Location;
 }
 
 /**

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -101,7 +101,7 @@ export const useQueryParam = <D, D2 = D>(
 
       updateUrlQuery(
         { [name]: newEncodedValue },
-        refLocation.current, // see #46 for why we use a ref here
+        refHistory.current.location || refLocation.current, // see #46 for why we use a ref here
         refHistory.current,
         updateType
       );

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -102,7 +102,7 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
       // update the URL
       updateUrlQuery(
         encodedChanges,
-        refLocation.current, // see #46
+        refHistory.current.location || refLocation.current, // see #46
         refHistory.current,
         updateType
       );


### PR DESCRIPTION
fixes #54
It looks like `refLocation` doesn't get an update when there's several concurrent setters being called in the context of react router. `history.location` is properly updated however. Had that issue in my app as well under similar conditions.

I did not test in the context of the reach router but I'm assuming it would default to the previous `|| refLocation.current` behavior.

another option is to always refer to `window.location` but that seemed nasty to me... 