### PR TITLE
Fix multiple updates in a single render in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ is one of `'replace' | 'replaceIn' | 'push' | 'pushIn'`, defaulting to
 `'replaceIn'`.
 
 You may optionally pass in a rawQuery object, otherwise the query is derived
-from the location in QueryParamProvider's context.
+from the location in the context.
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ is one of `'replace' | 'replaceIn' | 'push' | 'pushIn'`, defaulting to
 `'replaceIn'`.
 
 You may optionally pass in a rawQuery object, otherwise the query is derived
-from the location available in the QueryParamContext.
+from the location in QueryParamProvider's context.
 
 **Example**
 

--- a/src/LocationContext.ts
+++ b/src/LocationContext.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { EncodedQueryWithNulls } from 'serialize-query-params';
+
+import { UrlUpdateType } from './types';
+
+/**
+ * Shape of the LocationProviderContext, which the hooks consume to read and
+ * update the URL state.
+ */
+type LocationProviderContext = [
+  Location,
+  (queryReplacements: EncodedQueryWithNulls, updateType?: UrlUpdateType) => void
+];
+
+export const LocationContext = React.createContext<LocationProviderContext>([
+  {} as Location,
+  () => {},
+]);

--- a/src/LocationProvider.tsx
+++ b/src/LocationProvider.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { UrlUpdateType, PushReplaceHistory } from './types';
+
+type LocationProviderContext = [
+  Location,
+  (
+    updater: (oldLocation: Location) => Location,
+    updateType?: UrlUpdateType
+  ) => void
+];
+
+export const LocationContext = React.createContext<LocationProviderContext>([
+  {} as Location,
+  () => {},
+]);
+
+export interface HistoryLocation {
+  /** History that meets the { replace, push } interface */
+  history: PushReplaceHistory;
+  /** * Initial location object */
+  location: Location;
+}
+
+/**
+ * Props for the internal-only Location Provider component.
+ */
+interface LocationProviderProps {
+  /** Main app goes here */
+  children: React.ReactNode;
+  /** History that meets the { replace, push } interface */
+  history: PushReplaceHistory;
+  /** * Initial location object */
+  location: Location;
+}
+
+export function LocationProvider({
+  location,
+  history,
+  children,
+}: LocationProviderProps) {
+  const locationRef = React.useRef(location);
+  React.useEffect(() => {
+    locationRef.current = location;
+  }, [location]);
+
+  const setContext = React.useCallback(
+    (
+      updater: (oldLocation: Location) => Location,
+      updateType?: UrlUpdateType
+    ) => {
+      // Location ref needed to stop setContext updating constantly - see #46
+      locationRef.current = updater(locationRef.current);
+      switch (updateType) {
+        case 'pushIn':
+        case 'push':
+          history.push(locationRef.current);
+          break;
+        case 'replaceIn':
+        case 'replace':
+        default:
+          history.replace(locationRef.current);
+          break;
+      }
+    },
+    [history]
+  );
+
+  return (
+    <LocationContext.Provider value={[location, setContext]}>
+      {children}
+    </LocationContext.Provider>
+  );
+}

--- a/src/QueryParamProvider.tsx
+++ b/src/QueryParamProvider.tsx
@@ -1,26 +1,6 @@
 import * as React from 'react';
-import { PushReplaceHistory } from './types';
-import {
-  LocationContext,
-  LocationProvider,
-  HistoryLocation,
-} from './LocationProvider';
-
-export { LocationContext };
-
-/**
- * Subset of a @reach/router history object. We only
- * care about the navigate function.
- */
-interface ReachHistory {
-  navigate: (
-    to: string,
-    options?: {
-      state?: any;
-      replace?: boolean;
-    }
-  ) => void;
-}
+import { HistoryLocation, PushReplaceHistory } from './types';
+import { LocationProvider } from './LocationProvider';
 
 /**
  * Adapts standard DOM window history to work with our
@@ -45,6 +25,20 @@ function adaptWindowHistory(history: History): PushReplaceHistory {
       );
     },
   };
+}
+
+/**
+ * Subset of a @reach/router history object. We only
+ * care about the navigate function.
+ */
+interface ReachHistory {
+  navigate: (
+    to: string,
+    options?: {
+      state?: any;
+      replace?: boolean;
+    }
+  ) => void;
 }
 
 /**
@@ -73,26 +67,26 @@ function adaptReachHistory(history: ReachHistory): PushReplaceHistory {
 /**
  * Helper to produce the context value falling back to
  * window history and location if not provided.
- *
- * TODO type better.
  */
-function getLocationProps({
+export function getLocationProps({
   history,
   location,
-}: Partial<HistoryLocation> = {}) {
-  const value = { history, location };
-
+}: Partial<HistoryLocation> = {}): HistoryLocation {
   const hasWindow = typeof window !== 'undefined';
   if (hasWindow) {
-    if (!value.history) {
-      value.history = adaptWindowHistory(window.history);
+    if (!history) {
+      history = adaptWindowHistory(window.history);
     }
-    if (!value.location) {
-      value.location = window.location;
+    if (!location) {
+      location = window.location;
     }
   }
-
-  return value as HistoryLocation;
+  if (!location) {
+    throw new Error(`
+        Could not read the location. Is the router wired up correctly?
+      `);
+  }
+  return { history, location };
 }
 
 /**

--- a/src/__tests__/QueryParamProvider-test.tsx
+++ b/src/__tests__/QueryParamProvider-test.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { render, cleanup } from '@testing-library/react';
-import { QueryParamProvider, QueryParamContext } from '../index';
+import { QueryParamProvider } from '../QueryParamProvider';
 import { makeMockLocation, makeMockHistory } from './helpers';
+
+// ¯\_(ツ)_/¯
+jest.mock('../LocationProvider', () => ({
+  LocationProvider: ({ history, children }) => children({ history }),
+}));
 
 describe('QueryParamProvider', () => {
   afterEach(cleanup);
@@ -11,13 +16,11 @@ describe('QueryParamProvider', () => {
 
     const tree = (
       <QueryParamProvider reachHistory={reachHistory}>
-        <QueryParamContext.Consumer>
-          {({ history }) => {
-            history.replace(makeMockLocation({ foo: '123' }));
-            history.push(makeMockLocation({ bar: 'zzz' }));
-            return <div>consumed</div>;
-          }}
-        </QueryParamContext.Consumer>
+        {({ history }) => {
+          history.replace(makeMockLocation({ foo: '123' }));
+          history.push(makeMockLocation({ bar: 'zzz' }));
+          return <div>consumed</div>;
+        }}
       </QueryParamProvider>
     );
 
@@ -41,13 +44,11 @@ describe('QueryParamProvider', () => {
 
     const tree = (
       <QueryParamProvider ReactRouterRoute={MockRoute}>
-        <QueryParamContext.Consumer>
-          {({ history }) => {
-            history.replace(makeMockLocation({ foo: '123' }));
-            history.push(makeMockLocation({ bar: 'zzz' }));
-            return <div>consumed</div>;
-          }}
-        </QueryParamContext.Consumer>
+        {({ history }) => {
+          history.replace(makeMockLocation({ foo: '123' }));
+          history.push(makeMockLocation({ bar: 'zzz' }));
+          return <div>consumed</div>;
+        }}
       </QueryParamProvider>
     );
 
@@ -64,14 +65,12 @@ describe('QueryParamProvider', () => {
 
     const tree = (
       <QueryParamProvider>
-        <QueryParamContext.Consumer>
-          {({ history }) => {
-            windowHistory = history;
-            history.replace(makeMockLocation({ foo: '123' }));
-            history.push(makeMockLocation({ bar: 'zzz' }));
-            return <div>consumed</div>;
-          }}
-        </QueryParamContext.Consumer>
+        {({ history }) => {
+          windowHistory = history;
+          history.replace(makeMockLocation({ foo: '123' }));
+          history.push(makeMockLocation({ bar: 'zzz' }));
+          return <div>consumed</div>;
+        }}
       </QueryParamProvider>
     );
 

--- a/src/__tests__/updateUrlQuery-test.ts
+++ b/src/__tests__/updateUrlQuery-test.ts
@@ -7,8 +7,8 @@ import {
 } from './helpers';
 import { UrlUpdateType } from '../types';
 
-describe('updateUrlQuery', () => {
-  function update(
+describe('getLocation and updateUrlQuery', () => {
+  function getAndUpdateLocation(
     queryReplacements,
     location,
     history,
@@ -21,7 +21,7 @@ describe('updateUrlQuery', () => {
   it('replaceIn', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    update(
+    getAndUpdateLocation(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -36,7 +36,12 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    update({ foo: '123' }, makeMockLocation({}), history, 'replaceIn');
+    getAndUpdateLocation(
+      { foo: '123' },
+      makeMockLocation({}),
+      history,
+      'replaceIn'
+    );
     expect(calledReplaceQuery(history, 1)).toEqual({
       foo: '123',
     });
@@ -45,7 +50,7 @@ describe('updateUrlQuery', () => {
   it('pushIn', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    update(
+    getAndUpdateLocation(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -60,7 +65,12 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    update({ foo: '123' }, makeMockLocation({}), history, 'pushIn');
+    getAndUpdateLocation(
+      { foo: '123' },
+      makeMockLocation({}),
+      history,
+      'pushIn'
+    );
     expect(calledPushQuery(history, 1)).toEqual({
       foo: '123',
     });
@@ -69,7 +79,7 @@ describe('updateUrlQuery', () => {
   it('replace', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    update(
+    getAndUpdateLocation(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -83,7 +93,12 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    update({ foo: '123' }, makeMockLocation({}), history, 'replace');
+    getAndUpdateLocation(
+      { foo: '123' },
+      makeMockLocation({}),
+      history,
+      'replace'
+    );
     expect(calledReplaceQuery(history, 1)).toEqual({
       foo: '123',
     });
@@ -92,7 +107,7 @@ describe('updateUrlQuery', () => {
   it('push', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    update(
+    getAndUpdateLocation(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -106,7 +121,7 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    update({ foo: '123' }, makeMockLocation({}), history, 'push');
+    getAndUpdateLocation({ foo: '123' }, makeMockLocation({}), history, 'push');
     expect(calledPushQuery(history, 1)).toEqual({
       foo: '123',
     });

--- a/src/__tests__/updateUrlQuery-test.ts
+++ b/src/__tests__/updateUrlQuery-test.ts
@@ -1,16 +1,27 @@
-import { updateUrlQuery } from '../index';
+import { getLocation, updateUrlQuery } from '../updateUrlQuery';
 import {
   makeMockHistory,
   makeMockLocation,
   calledPushQuery,
   calledReplaceQuery,
 } from './helpers';
+import { UrlUpdateType } from '../types';
 
 describe('updateUrlQuery', () => {
+  function update(
+    queryReplacements,
+    location,
+    history,
+    updateType: UrlUpdateType = 'replaceIn'
+  ) {
+    const newLocation = getLocation(queryReplacements, location, updateType);
+    updateUrlQuery(history, newLocation, updateType);
+  }
+
   it('replaceIn', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    updateUrlQuery(
+    update(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -25,7 +36,7 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    updateUrlQuery({ foo: '123' }, makeMockLocation({}), history, 'replaceIn');
+    update({ foo: '123' }, makeMockLocation({}), history, 'replaceIn');
     expect(calledReplaceQuery(history, 1)).toEqual({
       foo: '123',
     });
@@ -34,7 +45,7 @@ describe('updateUrlQuery', () => {
   it('pushIn', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    updateUrlQuery(
+    update(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -49,7 +60,7 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    updateUrlQuery({ foo: '123' }, makeMockLocation({}), history, 'pushIn');
+    update({ foo: '123' }, makeMockLocation({}), history, 'pushIn');
     expect(calledPushQuery(history, 1)).toEqual({
       foo: '123',
     });
@@ -58,7 +69,7 @@ describe('updateUrlQuery', () => {
   it('replace', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    updateUrlQuery(
+    update(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -72,7 +83,7 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    updateUrlQuery({ foo: '123' }, makeMockLocation({}), history, 'replace');
+    update({ foo: '123' }, makeMockLocation({}), history, 'replace');
     expect(calledReplaceQuery(history, 1)).toEqual({
       foo: '123',
     });
@@ -81,7 +92,7 @@ describe('updateUrlQuery', () => {
   it('push', () => {
     const history = makeMockHistory();
     // test updating existing query param
-    updateUrlQuery(
+    update(
       { foo: '123' },
       makeMockLocation({ foo: '521', bar: 'zzz' }),
       history,
@@ -95,7 +106,7 @@ describe('updateUrlQuery', () => {
     });
 
     // test when no query params
-    updateUrlQuery({ foo: '123' }, makeMockLocation({}), history, 'push');
+    update({ foo: '123' }, makeMockLocation({}), history, 'push');
     expect(calledPushQuery(history, 1)).toEqual({
       foo: '123',
     });

--- a/src/__tests__/useQueryParam-test.tsx
+++ b/src/__tests__/useQueryParam-test.tsx
@@ -106,4 +106,27 @@ describe('useQueryParam', () => {
     const [, setter2] = result.current;
     expect(setter).toBe(setter2);
   });
+
+  it('sets distinct params in the same render', () => {
+    const { wrapper } = setupWrapper({
+      foo: '1',
+      bar: '1',
+    });
+    const { result, rerender } = renderHook(
+      () => [
+        useQueryParam('foo', NumberParam),
+        useQueryParam('bar', NumberParam),
+      ],
+      { wrapper }
+    );
+    const [[foo1, setFoo], [bar1, setBar]] = result.current;
+    expect([foo1, bar1]).toEqual([1, 1]);
+
+    setFoo(2, 'replaceIn');
+    setBar(2, 'replaceIn');
+    rerender();
+
+    const [[foo2], [bar2]] = result.current;
+    expect([foo2, bar2]).toEqual([2, 2]); // Fails, instead receiving [1, 2]
+  });
 });

--- a/src/__tests__/useQueryParams-test.tsx
+++ b/src/__tests__/useQueryParams-test.tsx
@@ -109,4 +109,41 @@ describe('useQueryParams', () => {
     const [, setter2] = result.current;
     expect(setter).toBe(setter2);
   });
+
+  it('sets distinct params in the same render', () => {
+    const { wrapper } = setupWrapper({ foo: '123', bar: 'xxx' });
+    const { result, rerender } = renderHook(
+      () => useQueryParams({ foo: NumberParam, bar: StringParam }),
+      {
+        wrapper,
+      }
+    );
+    const [, setter] = result.current;
+
+    setter({ foo: 999 }, 'replaceIn');
+    setter({ bar: 'yyy' }, 'replaceIn');
+    rerender();
+    const [decodedQuery] = result.current;
+    expect(decodedQuery).toEqual({ foo: 999, bar: 'yyy' });
+  });
+
+  it('sets distinct params with different hooks in the same render', () => {
+    const { wrapper } = setupWrapper({ foo: '123', bar: 'xxx' });
+    const { result, rerender } = renderHook(
+      () => [
+        useQueryParams({ foo: NumberParam }),
+        useQueryParams({ bar: StringParam }),
+      ],
+      {
+        wrapper,
+      }
+    );
+    const [[, setFoo], [, setBar]] = result.current;
+
+    setFoo({ foo: 999 }, 'replaceIn');
+    setBar({ bar: 'yyy' }, 'replaceIn');
+    rerender();
+    const [[{ foo }], [{ bar }]] = result.current;
+    expect({ foo, bar }).toEqual({ foo: 999, bar: 'yyy' });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,4 @@ export { useQueryParam } from './useQueryParam';
 export { useQueryParams } from './useQueryParams';
 export { withQueryParams, InjectedQueryProps } from './withQueryParams';
 export { QueryParams, QueryParamsProps, QueryRenderProps } from './QueryParams';
-export {
-  QueryParamProvider,
-  QueryParamContext,
-  QueryParamContextValue,
-} from './QueryParamProvider';
+export { QueryParamProvider } from './QueryParamProvider';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ export { useQueryParam } from './useQueryParam';
 export { useQueryParams } from './useQueryParams';
 export { withQueryParams, InjectedQueryProps } from './withQueryParams';
 export { QueryParams, QueryParamsProps, QueryRenderProps } from './QueryParams';
-export { updateUrlQuery } from './updateUrlQuery';
 export {
   QueryParamProvider,
   QueryParamContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,6 @@ export type UrlUpdateType = 'replace' | 'replaceIn' | 'push' | 'pushIn';
 export interface PushReplaceHistory {
   push: (location: Location) => void;
   replace: (location: Location) => void;
-  location?: Location;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,3 +26,13 @@ export type SetQuery<QPCMap extends QueryParamConfigMap> = (
   changes: Partial<DecodedValueMap<QPCMap>>,
   updateType?: UrlUpdateType
 ) => void;
+
+export interface HistoryLocation {
+  /**
+   * History that meets the { replace, push } interface.
+   * May be missing when run server-side.
+   */
+  history?: PushReplaceHistory;
+  /** The location object */
+  location: Location;
+}

--- a/src/updateUrlQuery.ts
+++ b/src/updateUrlQuery.ts
@@ -6,7 +6,7 @@ import {
 import { PushReplaceHistory, UrlUpdateType } from './types';
 
 /**
- * Creates a new location containing the specified query changes.
+ * Creates a new location object containing the specified query changes.
  * If replaceIn or pushIn are used as the updateType, then parameters
  * not specified in queryReplacements are retained. If replace or push
  * are used, only the values in queryReplacements will be available.
@@ -17,14 +17,13 @@ export function getLocation(
   updateType: UrlUpdateType = 'replaceIn'
 ): Location {
   switch (updateType) {
-    case 'replaceIn':
-    case 'pushIn':
-      return updateInLocation(queryReplacements, location);
     case 'replace':
     case 'push':
       return updateLocation(queryReplacements, location);
+    case 'replaceIn':
+    case 'pushIn':
     default:
-      throw new Error('Invalid updateType');
+      return updateInLocation(queryReplacements, location);
   }
 }
 
@@ -37,14 +36,14 @@ export function updateUrlQuery(
   updateType: UrlUpdateType = 'replaceIn'
 ): void {
   switch (updateType) {
-    case 'replaceIn':
-    case 'replace':
-      history.replace(location);
-      break;
     case 'pushIn':
     case 'push':
       history.push(location);
       break;
+    case 'replaceIn':
+    case 'replace':
     default:
+      history.replace(location);
+      break;
   }
 }

--- a/src/updateUrlQuery.ts
+++ b/src/updateUrlQuery.ts
@@ -6,32 +6,45 @@ import {
 import { PushReplaceHistory, UrlUpdateType } from './types';
 
 /**
- * Updates the URL to match the specified query changes.
+ * Creates a new location containing the specified query changes.
  * If replaceIn or pushIn are used as the updateType, then parameters
  * not specified in queryReplacements are retained. If replace or push
  * are used, only the values in queryReplacements will be available.
  */
-export function updateUrlQuery(
+export function getLocation(
   queryReplacements: EncodedQueryWithNulls,
   location: Location,
+  updateType: UrlUpdateType = 'replaceIn'
+): Location {
+  switch (updateType) {
+    case 'replaceIn':
+    case 'pushIn':
+      return updateInLocation(queryReplacements, location);
+    case 'replace':
+    case 'push':
+      return updateLocation(queryReplacements, location);
+    default:
+      throw new Error('Invalid updateType');
+  }
+}
+
+/**
+ * Updates the URL to the new location.
+ */
+export function updateUrlQuery(
   history: PushReplaceHistory,
+  location: Location,
   updateType: UrlUpdateType = 'replaceIn'
 ): void {
   switch (updateType) {
     case 'replaceIn':
-      history.replace(updateInLocation(queryReplacements, location));
+    case 'replace':
+      history.replace(location);
       break;
     case 'pushIn':
-      history.push(updateInLocation(queryReplacements, location));
-      break;
-    case 'replace':
-      history.replace(updateLocation(queryReplacements, location));
-      break;
     case 'push':
-      history.push(updateLocation(queryReplacements, location));
+      history.push(location);
       break;
     default:
   }
 }
-
-export default updateUrlQuery;

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -19,7 +19,7 @@ import { UrlUpdateType } from './types';
  * 'replaceIn'.
  *
  * You may optionally pass in a rawQuery object, otherwise the query is derived
- * from the location available in the QueryParamContext.
+ * from the location available in the context.
  *
  * D = decoded type
  * D2 = return value from decode (typically same as D)

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -7,8 +7,7 @@ import {
   StringParam,
   QueryParamConfig,
 } from 'serialize-query-params';
-import { LocationContext } from './QueryParamProvider';
-import { getLocation } from './updateUrlQuery';
+import { LocationContext } from './LocationContext';
 import { UrlUpdateType } from './types';
 
 /**
@@ -86,10 +85,7 @@ export const useQueryParam = <D, D2 = D>(
   const setValue = React.useCallback(
     (newValue: D, updateType?: UrlUpdateType) => {
       const newEncodedValue = paramConfig.encode(newValue);
-      setLocation(
-        l => getLocation({ [name]: newEncodedValue }, l, updateType),
-        updateType
-      );
+      setLocation({ [name]: newEncodedValue }, updateType);
     },
     [setLocation, paramConfig, name]
   );

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -101,7 +101,7 @@ export const useQueryParam = <D, D2 = D>(
 
       updateUrlQuery(
         { [name]: newEncodedValue },
-        refHistory.current.location || refLocation.current, // see #46 for why we use a ref here
+        refLocation.current, // see #46 for why we use a ref here
         refHistory.current,
         updateType
       );

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -8,7 +8,7 @@ import {
   QueryParamConfig,
 } from 'serialize-query-params';
 import { QueryParamContext } from './QueryParamProvider';
-import { updateUrlQuery } from './updateUrlQuery';
+import { getLocation, updateUrlQuery } from './updateUrlQuery';
 import { UrlUpdateType } from './types';
 
 /**
@@ -99,12 +99,12 @@ export const useQueryParam = <D, D2 = D>(
     (newValue: D, updateType?: UrlUpdateType) => {
       const newEncodedValue = paramConfig.encode(newValue);
 
-      updateUrlQuery(
+      refLocation.current = getLocation(
         { [name]: newEncodedValue },
         refLocation.current, // see #46 for why we use a ref here
-        refHistory.current,
         updateType
       );
+      updateUrlQuery(refHistory.current, refLocation.current, updateType);
     },
     [paramConfig, name]
   );

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -102,7 +102,7 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
       // update the URL
       updateUrlQuery(
         encodedChanges,
-        refHistory.current.location || refLocation.current, // see #46
+        refLocation.current, // see #46
         refHistory.current,
         updateType
       );

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -7,8 +7,7 @@ import {
   QueryParamConfigMap,
 } from 'serialize-query-params';
 import { useQueryParam } from './useQueryParam';
-import { getLocation } from './updateUrlQuery';
-import { LocationContext } from './QueryParamProvider';
+import { LocationContext } from './LocationContext';
 import { UrlUpdateType, SetQuery } from './types';
 
 // from https://usehooks.com/usePrevious/
@@ -88,7 +87,7 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
       );
 
       // update the URL
-      setLocation(l => getLocation(encodedChanges, l, updateType), updateType);
+      setLocation(encodedChanges, updateType);
     },
     [setLocation, paramConfigMap]
   );

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -7,7 +7,7 @@ import {
   QueryParamConfigMap,
 } from 'serialize-query-params';
 import { useQueryParam } from './useQueryParam';
-import updateUrlQuery from './updateUrlQuery';
+import { getLocation, updateUrlQuery } from './updateUrlQuery';
 import { QueryParamContext } from './QueryParamProvider';
 import { UrlUpdateType, SetQuery } from './types';
 
@@ -100,12 +100,12 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
       );
 
       // update the URL
-      updateUrlQuery(
+      refLocation.current = getLocation(
         encodedChanges,
-        refLocation.current, // see #46
-        refHistory.current,
+        refLocation.current, // see #46 for why we use a ref here
         updateType
       );
+      updateUrlQuery(refHistory.current, refLocation.current, updateType);
     },
     [paramConfigMap]
   );


### PR DESCRIPTION
Resolves #62 . This is a follow-on from issue #54 and PR #61 , but the fix doesn't require `history` to have `history.location` defined, so now works with tests outside a browser.

The approach I took was to move the refs up. Rather than each useQueryParam/s hook maintaining its own ref of the last version of the location it received, the top level provider should maintain a single location ref instead, and updates to the location should work with this shared ref. (The previous approach in #61 was like a shared ref approach, too: when it exists, `refHistory.current.location` is up-to-date everywhere in the app because there's only one history, but `refLocation.current` isn't guaranteed to be up-to-date if two different hooks call setQuery without re-rendering between calls.) I introduced a new internal-only `LocationProvider` component to manage this ref and provide down a single cached updater callback.