### PR TITLE
Rework code to allow dynamic changes to query param config #72

### DIFF
--- a/src/__tests__/QueryParams-test.tsx
+++ b/src/__tests__/QueryParams-test.tsx
@@ -6,13 +6,13 @@ import {
   NumberParam,
   StringParam,
   DecodedValueMap,
-  EncodedQueryWithNulls,
+  EncodedQuery,
 } from 'serialize-query-params';
 import { SetQuery, QueryParams, QueryParamProvider } from '../index';
 import { makeMockHistory, makeMockLocation, calledPushQuery } from './helpers';
 
 // helper to setup tests
-function setupWrapper(query: EncodedQueryWithNulls) {
+function setupWrapper(query: EncodedQuery) {
   const location = makeMockLocation(query);
   const history = makeMockHistory(location);
   const wrapper = ({ children }: any) => (

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-import { EncodedQueryWithNulls } from 'serialize-query-params';
+import { EncodedQuery } from 'serialize-query-params';
 import { stringify, parse as parseQueryString } from 'query-string';
 
 // if passed a location, will mutate it so we can see what changes are being made
@@ -6,10 +6,14 @@ export function makeMockHistory(location: any = {}) {
   return {
     replace: jest
       .fn()
-      .mockImplementation(newLocation => Object.assign(location, newLocation)),
+      .mockImplementation((newLocation) =>
+        Object.assign(location, newLocation)
+      ),
     push: jest
       .fn()
-      .mockImplementation(newLocation => Object.assign(location, newLocation)),
+      .mockImplementation((newLocation) =>
+        Object.assign(location, newLocation)
+      ),
   };
 }
 
@@ -29,7 +33,7 @@ export function calledPushQuery(
   return parseQueryString(history.push.mock.calls[index][0].search);
 }
 
-export function makeMockLocation(query: EncodedQueryWithNulls): Location {
+export function makeMockLocation(query: EncodedQuery): Location {
   const queryStr = stringify(query);
   return {
     protocol: 'http:',

--- a/src/__tests__/useQueryParam-test.tsx
+++ b/src/__tests__/useQueryParam-test.tsx
@@ -3,7 +3,7 @@ import { renderHook, cleanup } from 'react-hooks-testing-library';
 import {
   NumberParam,
   NumericArrayParam,
-  EncodedQueryWithNulls,
+  EncodedQuery,
 } from 'serialize-query-params';
 
 import { useQueryParam, QueryParamProvider } from '../index';
@@ -15,7 +15,7 @@ import {
 } from './helpers';
 
 // helper to setup tests
-function setupWrapper(query: EncodedQueryWithNulls) {
+function setupWrapper(query: EncodedQuery) {
   const location = makeMockLocation(query);
   const history = makeMockHistory(location);
   const wrapper = ({ children }: any) => (
@@ -32,7 +32,6 @@ function setupWrapper(query: EncodedQueryWithNulls) {
 
 describe('useQueryParam', () => {
   afterEach(cleanup);
-
   it('default param type (string, pushIn)', () => {
     const { wrapper, history } = setupWrapper({ foo: '123', bar: 'xxx' });
     const { result } = renderHook(() => useQueryParam('foo'), { wrapper });
@@ -76,8 +75,8 @@ describe('useQueryParam', () => {
     setter2([4, 5, 6], 'replaceIn');
     rerender();
     const [decodedValue3, setter3] = result.current;
-    expect(decodedValue).not.toBe(decodedValue3);
     expect(decodedValue3).toEqual([4, 5, 6]);
+    expect(decodedValue).not.toBe(decodedValue3);
 
     setter3([4, 5, 6], 'push');
     rerender();

--- a/src/__tests__/withQueryParams-test.tsx
+++ b/src/__tests__/withQueryParams-test.tsx
@@ -6,13 +6,13 @@ import {
   NumberParam,
   StringParam,
   DecodedValueMap,
-  EncodedQueryWithNulls,
+  EncodedQuery,
 } from 'serialize-query-params';
 import { SetQuery, withQueryParams, QueryParamProvider } from '../index';
 import { makeMockHistory, makeMockLocation, calledPushQuery } from './helpers';
 
 // helper to setup tests
-function setupWrapper(query: EncodedQueryWithNulls) {
+function setupWrapper(query: EncodedQuery) {
   const location = makeMockLocation(query);
   const history = makeMockHistory(location);
   const wrapper = ({ children }: any) => (

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { extract } from 'query-string';
+import shallowEqual from './shallowEqual';
+
+export function usePreviousIfShallowEqual<T>(value: T) {
+  const ref = React.useRef(value);
+  const hasNew = !shallowEqual(ref.current, value);
+  React.useEffect(() => {
+    if (hasNew) {
+      ref.current = value;
+    }
+  }, [value, hasNew]);
+  return hasNew ? value : ref.current;
+}
+
+export function getSSRSafeSearchString(location: Location | undefined) {
+  // handle checking SSR (#13)
+  if (typeof location === 'object') {
+    // in browser
+    if (typeof window !== 'undefined') {
+      return location.search;
+    } else {
+      return extract(
+        `${location.pathname}${location.search ? location.search : ''}`
+      );
+    }
+  }
+
+  return '';
+}

--- a/src/memoizedQueryParser.ts
+++ b/src/memoizedQueryParser.ts
@@ -1,0 +1,20 @@
+import { parse as parseQueryString } from 'query-string';
+import { EncodedQuery } from 'serialize-query-params';
+
+export const makeMemoizedQueryParser = (
+  initialSearchString?: string | undefined
+) => {
+  let cachedSearchString = initialSearchString;
+  let cachedParsedQuery = parseQueryString(cachedSearchString || '');
+
+  return (newSearchString: string): EncodedQuery => {
+    if (cachedSearchString !== newSearchString) {
+      cachedSearchString = newSearchString;
+      cachedParsedQuery = parseQueryString(cachedSearchString);
+    }
+
+    return cachedParsedQuery;
+  };
+};
+
+export const sharedMemoizedQueryParser = makeMemoizedQueryParser();

--- a/src/shallowEqual.ts
+++ b/src/shallowEqual.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license at
+ * https://github.com/facebook/fbjs/blob/master/LICENSE
+ */
+
+/*eslint-disable no-self-compare */
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * inlined Object.is polyfill to avoid requiring consumers ship their own
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+ */
+function is(x: any, y: any): boolean {
+  // SameValue algorithm
+  if (x === y) {
+    // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    // Added the nonzero y check to make Flow happy, but it is redundant
+    return x !== 0 || y !== 0 || 1 / x === 1 / y;
+  } else {
+    // Step 6.a: NaN == NaN
+    return x !== x && y !== y;
+  }
+}
+
+/**
+ * Performs equality by iterating through keys on an object and returning false
+ * when any key has values which are not strictly equal between the arguments.
+ * Returns true when the values of all keys are strictly equal.
+ */
+export default function shallowEqual(objA: any, objB: any): boolean {
+  if (is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !hasOwnProperty.call(objB, keysA[i]) ||
+      !is(objA[keysA[i]], objB[keysA[i]])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = shallowEqual;

--- a/src/updateUrlQuery.ts
+++ b/src/updateUrlQuery.ts
@@ -1,5 +1,5 @@
 import {
-  EncodedQueryWithNulls,
+  EncodedQuery,
   updateLocation,
   updateInLocation,
 } from 'serialize-query-params';
@@ -13,7 +13,7 @@ import { PushReplaceHistory, UrlUpdateType } from './types';
  * The default is pushIn.
  */
 export function updateUrlQuery(
-  queryReplacements: EncodedQueryWithNulls,
+  queryReplacements: EncodedQuery,
   location: Location,
   history: PushReplaceHistory,
   updateType: UrlUpdateType = 'pushIn'

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -1,18 +1,10 @@
 import * as React from 'react';
-import {
-  parse as parseQueryString,
-  parseUrl as parseQueryURL,
-  stringify,
-} from 'query-string';
-
-import {
-  EncodedQueryWithNulls,
-  StringParam,
-  QueryParamConfig,
-} from 'serialize-query-params';
+import { QueryParamConfig, StringParam } from 'serialize-query-params';
+import { getSSRSafeSearchString, usePreviousIfShallowEqual } from './helpers';
+import { sharedMemoizedQueryParser } from './memoizedQueryParser';
 import { useQueryParamContext } from './QueryParamProvider';
-import { updateUrlQuery } from './updateUrlQuery';
 import { UrlUpdateType } from './types';
+import { updateUrlQuery } from './updateUrlQuery';
 
 /**
  * Given a query param name and query parameter configuration ({ encode, decode })
@@ -30,68 +22,9 @@ import { UrlUpdateType } from './types';
  */
 export const useQueryParam = <D, D2 = D>(
   name: string,
-  paramConfig: QueryParamConfig<D, D2> = StringParam as QueryParamConfig<any>,
-  rawQuery?: EncodedQueryWithNulls
+  paramConfig: QueryParamConfig<D, D2> = StringParam as QueryParamConfig<any>
 ): [D2 | undefined, (newValue: D, updateType?: UrlUpdateType) => void] => {
   const { history, location } = useQueryParamContext();
-
-  // ref with current version history object (see #46)
-  const refHistory = React.useRef(history);
-  React.useEffect(() => {
-    refHistory.current = history;
-  }, [history]);
-
-  // ref with current version location object (see #46)
-  const refLocation = React.useRef(location);
-  React.useEffect(() => {
-    refLocation.current = location;
-  }, [location]);
-
-  // read in the raw query
-  if (!rawQuery) {
-    const locationIsObject = typeof location === 'object';
-    const windowIsDefined = typeof window !== 'undefined';
-    rawQuery = React.useMemo(() => {
-      let pathname = {};
-
-      // handle checking SSR (#13)
-      if (locationIsObject) {
-        // in browser
-        if (windowIsDefined) {
-          pathname = parseQueryString(location.search);
-        } else {
-          // not in browser
-          let url = location.pathname;
-          if (location.search) {
-            url += location.search;
-          }
-
-          pathname = parseQueryURL(url).query;
-        }
-      }
-
-      return pathname || {};
-    }, [location.search, location.pathname, locationIsObject, windowIsDefined]);
-  }
-
-  // read in the encoded string value
-  const encodedValue = rawQuery[name];
-
-  // note that we use the stringified encoded value since the encoded
-  // value may be an array that is recreated if a different query param
-  // changes. It is sufficient to use this instead of encodedValue in
-  // the useMemo dependency array since it will change any time the actual
-  // meaningful value of encodedValue changes.
-  const arraySafeEncodedValue =
-    encodedValue instanceof Array
-      ? stringify({ [name]: encodedValue })
-      : encodedValue;
-
-  // decode if the encoded value has changed, otherwise
-  // re-use memoized value
-  const decodedValue = React.useMemo(() => {
-    return paramConfig.decode(encodedValue);
-  }, [arraySafeEncodedValue, paramConfig]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // create the setter, memoizing via useCallback
   const setValue = React.useCallback(
@@ -107,6 +40,34 @@ export const useQueryParam = <D, D2 = D>(
     },
     [paramConfig, name]
   );
+
+  // ref with current version history object (see #46)
+  const refHistory = React.useRef(history);
+  React.useEffect(() => {
+    refHistory.current = history;
+  }, [history]);
+
+  // ref with current version location object (see #46)
+  const refLocation = React.useRef(location);
+  React.useEffect(() => {
+    refLocation.current = location;
+  }, [location]);
+
+  // read in the raw query
+  const parsedQuery = sharedMemoizedQueryParser(
+    getSSRSafeSearchString(location)
+  );
+
+  // read in the encoded string value (we have to use previous if available because
+  // sometimes the query string changes so we get a new parsedQuery but this value
+  // didn't change, so we should avoid generating a new array or whatever value)
+  const encodedValue = usePreviousIfShallowEqual(parsedQuery[name]);
+
+  // decode if the encoded value has changed, otherwise
+  // re-use memoized value
+  const decodedValue = React.useMemo(() => {
+    return paramConfig.decode(encodedValue);
+  }, [encodedValue, paramConfig]);
 
   return [decodedValue, setValue];
 };


### PR DESCRIPTION
- Resolves #72 by reworking the code to not break rules of hooks, use simple caches instead of useMemo.