### PR TITLE
Add support for stringifying options

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,25 @@ const link = `/?${stringify(encodedQuery)}`;
 <QueryParamProvider reachHistory={globalHisory}><App /></QueryParamProvider>
 
 <QueryParamProvider history={myCustomHistory}><App /></QueryParamProvider>
+
+// optionally specify options to query-string stringify
+const stringifyOptions = { encode: false }
+<QueryParamProvider ReactRouterRoute={Route} stringifyOptions={stringifyOptions}>
+  <App />
+</QueryParamProvider>
+
+// also accepts a transformSearchString function (searchString: string) => string
+import {
+  ExtendedStringifyOptions,
+  transformSearchStringJsonSafe,
+} from 'use-query-params';
+
+const stringifyOptions: ExtendedStringifyOptions = {
+  transformSearchString: transformSearchStringJsonSafe,
+};
+<QueryParamProvider ReactRouterRoute={Route} stringifyOptions={stringifyOptions}>
+  <App />
+</QueryParamProvider>
 ```
 
 The **QueryParamProvider** component links your routing library's history to

--- a/examples/react-router/src/ReadmeExample2.tsx
+++ b/examples/react-router/src/ReadmeExample2.tsx
@@ -15,7 +15,7 @@ const UseQueryParamsExample = () => {
     filters: withDefault(ArrayParam, []),
   });
   const { x: num, q: searchQuery, filters } = query;
-  console.log('got filters =', filters);
+  console.log('got filters =', filters, num, searchQuery);
   return (
     <div>
       <h1>num is {num}</h1>

--- a/examples/react-router/src/ReadmeExample2.tsx
+++ b/examples/react-router/src/ReadmeExample2.tsx
@@ -15,7 +15,7 @@ const UseQueryParamsExample = () => {
     filters: withDefault(ArrayParam, []),
   });
   const { x: num, q: searchQuery, filters } = query;
-
+  console.log('got filters =', filters);
   return (
     <div>
       <h1>num is {num}</h1>

--- a/examples/react-router/src/UseQueryParamsExample.tsx
+++ b/examples/react-router/src/UseQueryParamsExample.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { useQueryParams, StringParam, NumberParam } from 'use-query-params';
+import {
+  useQueryParams,
+  StringParam,
+  NumberParam,
+  JsonParam,
+} from 'use-query-params';
 
 const UseQueryParamsExample = () => {
   const [count, setCount] = React.useState(0);
@@ -8,8 +13,9 @@ const UseQueryParamsExample = () => {
     zzz: NumberParam,
     test: StringParam,
     anyp: StringParam,
+    json: JsonParam,
   });
-  const { zzz, test, anyp } = query;
+  const { zzz, test, anyp, json } = query;
 
   return (
     <div className="UseQueryParamsExample">
@@ -76,6 +82,42 @@ const UseQueryParamsExample = () => {
                   onClick={() =>
                     setQuery(
                       { anyp: 'any' + Math.floor(Math.random() * 100) },
+                      'push'
+                    )
+                  }
+                >
+                  Change Push
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td>json</td>
+              <td>{JSON.stringify(json)}</td>
+              <td>{typeof json}</td>
+              <td>
+                <button
+                  onClick={() =>
+                    setQuery({
+                      json: {
+                        foo: [1, 2, 3],
+                        bar: { abc: 'def' },
+                        rand: 'any' + Math.floor(Math.random() * 100),
+                      },
+                    })
+                  }
+                >
+                  Change
+                </button>
+                <button
+                  onClick={() =>
+                    setQuery(
+                      {
+                        json: {
+                          foo: [1, 2, 3],
+                          bar: { abc: 'def' },
+                          rand: 'any' + Math.floor(Math.random() * 100),
+                        },
+                      },
                       'push'
                     )
                   }

--- a/examples/react-router/src/index.tsx
+++ b/examples/react-router/src/index.tsx
@@ -2,11 +2,22 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import App from './App';
-import { QueryParamProvider } from 'use-query-params';
+import {
+  QueryParamProvider,
+  ExtendedStringifyOptions,
+  transformSearchStringJsonSafe,
+} from 'use-query-params';
+
+const queryStringifyOptions: ExtendedStringifyOptions = {
+  transformSearchString: transformSearchStringJsonSafe,
+};
 
 ReactDOM.render(
   <Router>
-    <QueryParamProvider ReactRouterRoute={Route}>
+    <QueryParamProvider
+      ReactRouterRoute={Route}
+      stringifyOptions={queryStringifyOptions}
+    >
       <App />
     </QueryParamProvider>
   </Router>,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "serialize-query-params": "^1.0.1"
+    "serialize-query-params": "^1.1.0"
   },
   "husky": {
     "hooks": {

--- a/src/LocationProvider.tsx
+++ b/src/LocationProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EncodedQuery } from 'serialize-query-params';
+import { EncodedQuery, ExtendedStringifyOptions } from 'serialize-query-params';
 
 import { UrlUpdateType, HistoryLocation } from './types';
 import { updateUrlQuery, createLocationWithChanges } from './updateUrlQuery';
@@ -32,6 +32,7 @@ export function useLocationContext() {
 type LocationProviderProps = HistoryLocation & {
   /** Main app goes here */
   children: React.ReactNode;
+  stringifyOptions?: ExtendedStringifyOptions;
 };
 
 /**
@@ -42,6 +43,7 @@ export function LocationProvider({
   history,
   location,
   children,
+  stringifyOptions,
 }: LocationProviderProps) {
   const locationRef = React.useRef(location);
   React.useEffect(() => {
@@ -58,13 +60,14 @@ export function LocationProvider({
       locationRef.current = createLocationWithChanges(
         queryReplacements,
         locationRef.current,
-        updateType
+        updateType,
+        stringifyOptions
       );
       if (history) {
         updateUrlQuery(history, locationRef.current, updateType);
       }
     },
-    [history]
+    [history, stringifyOptions]
   );
 
   return (

--- a/src/LocationProvider.tsx
+++ b/src/LocationProvider.tsx
@@ -8,15 +8,20 @@ import { updateUrlQuery, createLocationWithChanges } from './updateUrlQuery';
  * Shape of the LocationProviderContext, which the hooks consume to read and
  * update the URL state.
  */
-type LocationProviderContext = [
-  () => Location,
-  (queryReplacements: EncodedQuery, updateType?: UrlUpdateType) => void
-];
+type LocationProviderContext = {
+  location: Location;
+  getLocation: () => Location;
+  setLocation: (
+    queryReplacements: EncodedQuery,
+    updateType?: UrlUpdateType
+  ) => void;
+};
 
-export const LocationContext = React.createContext<LocationProviderContext>([
-  () => ({} as Location),
-  () => {},
-]);
+export const LocationContext = React.createContext<LocationProviderContext>({
+  location: {} as Location,
+  getLocation: () => ({} as Location),
+  setLocation: () => {},
+});
 
 export function useLocationContext() {
   const context = React.useContext(LocationContext);
@@ -71,7 +76,7 @@ export function LocationProvider({
   );
 
   return (
-    <LocationContext.Provider value={[getLocation, setLocation]}>
+    <LocationContext.Provider value={{ location, getLocation, setLocation }}>
       {children}
     </LocationContext.Provider>
   );

--- a/src/updateUrlQuery.ts
+++ b/src/updateUrlQuery.ts
@@ -2,6 +2,7 @@ import {
   EncodedQuery,
   updateLocation,
   updateInLocation,
+  ExtendedStringifyOptions,
 } from 'serialize-query-params';
 import { PushReplaceHistory, UrlUpdateType } from './types';
 
@@ -15,16 +16,17 @@ import { PushReplaceHistory, UrlUpdateType } from './types';
 export function createLocationWithChanges(
   queryReplacements: EncodedQuery,
   location: Location,
-  updateType: UrlUpdateType = 'pushIn'
+  updateType: UrlUpdateType = 'pushIn',
+  stringifyOptions?: ExtendedStringifyOptions
 ): Location {
   switch (updateType) {
     case 'replace':
     case 'push':
-      return updateLocation(queryReplacements, location);
+      return updateLocation(queryReplacements, location, stringifyOptions);
     case 'replaceIn':
     case 'pushIn':
     default:
-      return updateInLocation(queryReplacements, location);
+      return updateInLocation(queryReplacements, location, stringifyOptions);
   }
 }
 

--- a/src/useQueryParam.ts
+++ b/src/useQueryParam.ts
@@ -13,7 +13,7 @@ type NewValueType<D> = D | ((latestValue: D) => D);
  * Abstracted into its own function to allow re-use in a functional setter (#26)
  */
 function getLatestDecodedValue<D, D2 = D>(
-  getLocation: () => Location,
+  location: Location,
   name: string,
   paramConfig: QueryParamConfig<D, D2>,
   paramConfigRef: React.MutableRefObject<QueryParamConfig<D, D2>>,
@@ -27,7 +27,7 @@ function getLatestDecodedValue<D, D2 = D>(
 
   // read in the parsed query
   const parsedQuery = sharedMemoizedQueryParser(
-    getSSRSafeSearchString(getLocation()) // get the latest location object
+    getSSRSafeSearchString(location) // get the latest location object
   );
 
   // read in the encoded string value (we have to check cache if available because
@@ -85,11 +85,11 @@ export const useQueryParam = <D, D2 = D>(
   D2 | undefined,
   (newValue: NewValueType<D>, updateType?: UrlUpdateType) => void
 ] => {
-  const [getLocation, setLocation] = useLocationContext();
+  const { location, getLocation, setLocation } = useLocationContext();
 
   // read in the raw query
   const parsedQuery = sharedMemoizedQueryParser(
-    getSSRSafeSearchString(getLocation())
+    getSSRSafeSearchString(location)
   );
 
   // make caches
@@ -98,7 +98,7 @@ export const useQueryParam = <D, D2 = D>(
   const decodedValueCacheRef = React.useRef<D2 | undefined>();
 
   const decodedValue = getLatestDecodedValue(
-    getLocation,
+    location,
     name,
     paramConfig,
     paramConfigRef,
@@ -123,7 +123,7 @@ export const useQueryParam = <D, D2 = D>(
       if (typeof newValue === 'function') {
         // get latest decoded value to pass as a fresh arg to the setter fn
         const latestValue = getLatestDecodedValue(
-          getLocation,
+          getLocation(),
           name,
           paramConfig,
           paramConfigRef,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5168,10 +5168,10 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-serialize-query-params@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.0.1.tgz#dcdaae4e6acfd32c127d1d36a45f0976a1745327"
-  integrity sha512-hh2ILw52Xgm76CIbsiVJGKOabldiDyQR2dWu37NsHAFRncbg4Ize9oVRMIPL4lhQuKaVhpszmZaI48Y75QAw+Q==
+serialize-query-params@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.1.0.tgz#b95a15bf0dd4a4df6162c4d72208f1a31e850459"
+  integrity sha512-CF/iHtjCDSj2FzBCsb8JBFruqERpCGgI+8L+236BxhZUwDclwxiOBELvP87HH5EbL9XElvvP+259mP0XgT6l5g==
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Resolves #23 by adding a `stringifyOptions` prop to `QueryParamProvider`
- fixes a bug in location resolving since #87 