### PR TITLE
Add some testing examples

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
         ignoreRestSiblings: false,
       },
     ],
-    'react-hooks/rules-of-hooks': 'off',
+    'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
   },
 };

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ A few basic [examples](https://github.com/pbeshai/use-query-params/tree/master/e
 - [React Router Example](https://github.com/pbeshai/use-query-params/tree/master/examples/react-router)
 - [Reach Router Example](https://github.com/pbeshai/use-query-params/tree/master/examples/reach-router)
 
+The React Router and Reach Router examples contain simple tests showing how to use the library with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
+
 ### API
 
 - [UrlUpdateType](#urlupdatetype)

--- a/examples/reach-router/package.json
+++ b/examples/reach-router/package.json
@@ -4,21 +4,24 @@
   "private": true,
   "dependencies": {
     "@reach/router": "^1.2.1",
+    "@testing-library/react": "^10.0.2",
     "@types/jest": "^24.0.11",
     "@types/node": "^11.11.2",
     "@types/reach__router": "^1.2.3",
     "@types/react": "^16.8.7",
     "@types/react-dom": "^16.8.2",
+    "jest-environment-jsdom-sixteen": "^1.0.3",
+    "query-string": "^6.12.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-scripts": "2.1.8",
+    "react-scripts": "^3.4.1",
     "typescript": "^3.3.3333",
     "use-query-params": "file:../.."
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/examples/reach-router/src/App.test.js
+++ b/examples/reach-router/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});

--- a/examples/reach-router/src/App.test.tsx
+++ b/examples/reach-router/src/App.test.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import {
+  Router,
+  LocationProvider,
+  createHistory,
+  createMemorySource,
+} from "@reach/router";
+import { parse } from "query-string";
+import { decodeQueryParams } from "serialize-query-params";
+import {
+  useQueryParam,
+  NumberParam,
+  QueryParamProvider,
+} from "use-query-params";
+
+function renderWithRouter(ui: React.ReactNode, initialRoute: string) {
+  const history = createHistory(createMemorySource(initialRoute));
+  const Component: React.FC<any> = () => ui;
+
+  return {
+    ...render(
+      <LocationProvider history={history}>
+        <Router>
+          <QueryParamProvider {...{ default: true }} reachHistory={history}>
+            <Component default />
+          </QueryParamProvider>
+        </Router>
+      </LocationProvider>
+    ),
+    history,
+  };
+}
+
+// An example counter component to be tested
+const QueryParamExample = () => {
+  const [x = 0, setX] = useQueryParam("x", NumberParam);
+  return (
+    <div>
+      <h1>{`x is ${x}`}</h1>
+      <button onClick={() => setX(x + 1)}>Change</button>
+    </div>
+  );
+};
+
+afterEach(cleanup);
+
+test("query param behaviour example", async () => {
+  const { queryByText, getByText } = renderWithRouter(
+    <QueryParamExample />,
+    "?x=3"
+  );
+
+  expect(queryByText(/x is 3/)).toBeTruthy();
+  getByText(/Change/).click();
+  await waitFor(() => {
+    expect(queryByText(/x is 4/)).toBeTruthy();
+  });
+});
+
+test("query param location example", async () => {
+  const { getByText, history } = renderWithRouter(
+    <QueryParamExample />,
+    "?x=3"
+  );
+  getByText(/Change/).click();
+  await waitFor(() => {
+    expect(
+      decodeQueryParams({ x: NumberParam }, parse(history.location.search))
+    ).toEqual({ x: 4 });
+  });
+});

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@testing-library/react": "^10.0.2",
     "@types/jest": "^24.0.11",
     "@types/node": "^11.11.2",
     "@types/react": "^16.8.7",

--- a/examples/react-router/src/App.test.js
+++ b/examples/react-router/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});

--- a/examples/react-router/src/App.test.tsx
+++ b/examples/react-router/src/App.test.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { Router } from "react-router";
+import { Route } from "react-router-dom";
+import { parse } from "query-string";
+import { decodeQueryParams } from "serialize-query-params";
+
+import {
+  useQueryParam,
+  NumberParam,
+  QueryParamProvider,
+} from "use-query-params";
+
+function renderWithRouter(ui: React.ReactNode, initialRoute: string) {
+  const history = createMemoryHistory({ initialEntries: [initialRoute] });
+  return {
+    ...render(
+      <Router history={history}>
+        <QueryParamProvider ReactRouterRoute={Route}>{ui}</QueryParamProvider>
+      </Router>
+    ),
+    history,
+  };
+}
+
+// An example counter component to be tested
+const QueryParamExample = () => {
+  const [x = 0, setX] = useQueryParam("x", NumberParam);
+  return (
+    <div>
+      <h1>{`x is ${x}`}</h1>
+      <button onClick={() => setX(x + 1)}>Change</button>
+    </div>
+  );
+};
+
+afterEach(cleanup);
+
+test("query param behaviour example", async () => {
+  const { queryByText, getByText } = renderWithRouter(
+    <QueryParamExample />,
+    "?x=3"
+  );
+
+  expect(queryByText(/x is 3/)).toBeTruthy();
+  getByText(/Change/).click();
+  expect(queryByText(/x is 4/)).toBeTruthy();
+});
+
+test("query param location example", async () => {
+  const { getByText, history } = renderWithRouter(
+    <QueryParamExample />,
+    "?x=3"
+  );
+  getByText(/Change/).click();
+  expect(
+    decodeQueryParams({ x: NumberParam }, parse(history.location.search))
+  ).toEqual({ x: 4 });
+});

--- a/src/__tests__/useQueryParam-test.tsx
+++ b/src/__tests__/useQueryParam-test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { cleanup, renderHook } from '@testing-library/react-hooks';
 import {
   EncodedQuery,
-  NumberParam,
-  NumericArrayParam,
+  // NumberParam,
+  // NumericArrayParam,
 } from 'serialize-query-params';
 import { QueryParamProvider, useQueryParam } from '../index';
 import { calledPushQuery, makeMockHistory, makeMockLocation } from './helpers';

--- a/src/__tests__/useQueryParam-test.tsx
+++ b/src/__tests__/useQueryParam-test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { cleanup, renderHook } from '@testing-library/react-hooks';
 import {
   EncodedQuery,
-  // NumberParam,
-  // NumericArrayParam,
+  NumberParam,
+  NumericArrayParam,
 } from 'serialize-query-params';
 import { QueryParamProvider, useQueryParam } from '../index';
 import { calledPushQuery, makeMockHistory, makeMockLocation } from './helpers';


### PR DESCRIPTION
The description in issue #80 is a bit brief, but it's a fair point that an example or two could help, and while it's mostly covered in the respective routing libraries' documentation, there are one or two subtleties.

I got some examples working for react-router and reach-router. The only difference in the tests are in the setup, and that reach router updates asynchronously so needs to `waitFor` the changes. I couldn't get anywhere with setting up found router in a test.