### PR TITLE
Allowing params to override shallowEqual

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "serialize-query-params": "^1.1.0"
+    "serialize-query-params": "^1.2.0"
   },
   "husky": {
     "hooks": {

--- a/src/__tests__/useQueryParam-test.tsx
+++ b/src/__tests__/useQueryParam-test.tsx
@@ -4,6 +4,7 @@ import {
   EncodedQuery,
   NumberParam,
   NumericArrayParam,
+  DateParam,
 } from 'serialize-query-params';
 import { QueryParamProvider, useQueryParam } from '../index';
 import { calledPushQuery, makeMockHistory, makeMockLocation } from './helpers';
@@ -149,5 +150,31 @@ describe('useQueryParam', () => {
     rerender();
     setter((latestValue: number) => latestValue + 100, 'push');
     expect(calledPushQuery(history, 2)).toEqual({ foo: '600' });
+  });
+
+  it('properly detects new values when equals is overridden', () => {
+    const { wrapper } = setupWrapper({
+      foo: '2020-01-01',
+    });
+    const { result, rerender } = renderHook(
+      () => useQueryParam('foo', DateParam),
+      {
+        wrapper,
+      }
+    );
+
+    const [decodedValue, setter] = result.current;
+    expect(decodedValue).toEqual(new Date(2020, 0, 1));
+
+    setter(new Date(2020, 0, 2));
+    rerender();
+    const [decodedValue2, setter2] = result.current;
+    expect(decodedValue2).toEqual(new Date(2020, 0, 2));
+    // expect(decodedValue).not.toBe(decodedValue3);
+
+    setter2(new Date(2020, 0, 2));
+    rerender();
+    const [decodedValue3] = result.current;
+    expect(decodedValue3).toBe(decodedValue2);
   });
 });

--- a/src/__tests__/useQueryParams-test.tsx
+++ b/src/__tests__/useQueryParams-test.tsx
@@ -6,6 +6,7 @@ import {
   StringParam,
   EncodedQuery,
   NumericArrayParam,
+  DateParam,
 } from 'serialize-query-params';
 
 import { useQueryParams, QueryParamProvider } from '../index';
@@ -259,5 +260,31 @@ describe('useQueryParams', () => {
     rerender();
     setter((latestQuery: any) => ({ foo: latestQuery.foo + 100 }), 'push');
     expect(calledPushQuery(history, 2)).toEqual({ foo: '600' });
+  });
+
+  it('properly detects new values when equals is overridden', () => {
+    const { wrapper } = setupWrapper({
+      foo: '2020-01-01',
+    });
+    const { result, rerender } = renderHook(
+      () => useQueryParams({ foo: DateParam }),
+      {
+        wrapper,
+      }
+    );
+
+    const [decodedValue, setter] = result.current;
+    expect(decodedValue.foo).toEqual(new Date(2020, 0, 1));
+
+    setter({ foo: new Date(2020, 0, 2) });
+    rerender();
+    const [decodedValue2, setter2] = result.current;
+    expect(decodedValue2.foo).toEqual(new Date(2020, 0, 2));
+    // expect(decodedValue).not.toBe(decodedValue3);
+
+    setter2({ foo: new Date(2020, 0, 2) });
+    rerender();
+    const [decodedValue3] = result.current;
+    expect(decodedValue3.foo).toBe(decodedValue2.foo);
   });
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,9 +4,15 @@ import shallowEqual from './shallowEqual';
 
 export function useUpdateRefIfShallowNew<T>(
   ref: React.MutableRefObject<T>,
-  newValue: T
+  newValue: T,
+  isEqual: (
+    objA: NonNullable<T>,
+    objB: NonNullable<T>
+  ) => boolean = shallowEqual
 ) {
-  const hasNew = !shallowEqual(ref.current, newValue);
+  const hasNew =
+    ((ref.current == null || newValue == null) && ref.current === newValue) ||
+    !isEqual(ref.current as NonNullable<T>, newValue as NonNullable<T>);
   React.useEffect(() => {
     if (hasNew) {
       ref.current = newValue;

--- a/src/shallowEqual.ts
+++ b/src/shallowEqual.ts
@@ -64,3 +64,42 @@ export default function shallowEqual(objA: any, objB: any): boolean {
 
   return true;
 }
+
+/**
+ * @pbeshai modification of shallowEqual to take into consideration a map providing
+ * equals functions
+ */
+export function shallowEqualMap(objA: any, objB: any, equalMap: any): boolean {
+  if (is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    const isEqual = equalMap[keysA[i]].equals ?? is;
+    if (
+      !hasOwnProperty.call(objB, keysA[i]) ||
+      !isEqual(objA[keysA[i]], objB[keysA[i]])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/useQueryParams.ts
+++ b/src/useQueryParams.ts
@@ -9,7 +9,7 @@ import {
 import { getSSRSafeSearchString, useUpdateRefIfShallowNew } from './helpers';
 import { useLocationContext } from './LocationProvider';
 import { sharedMemoizedQueryParser } from './memoizedQueryParser';
-import shallowEqual from './shallowEqual';
+import shallowEqual, { shallowEqualMap } from './shallowEqual';
 import { SetQuery, UrlUpdateType } from './types';
 
 type ChangesType<DecodedValueMapType> =
@@ -96,9 +96,10 @@ function getLatestDecodedValues<QPCMap extends QueryParamConfigMap>(
   }
 
   // keep referential equality for decoded valus if we didn't actually change anything
-  const hasNewDecodedValues = !shallowEqual(
+  const hasNewDecodedValues = !shallowEqualMap(
     decodedValuesCacheRef.current,
-    decodedValues
+    decodedValues,
+    paramConfigMap
   );
 
   return {
@@ -153,7 +154,10 @@ export const useQueryParams = <QPCMap extends QueryParamConfigMap>(
   useUpdateRefIfShallowNew(parsedQueryRef, parsedQuery);
   useUpdateRefIfShallowNew(paramConfigMapRef, paramConfigMap);
   useUpdateRefIfShallowNew(encodedValuesCacheRef, encodedValues);
-  useUpdateRefIfShallowNew(decodedValuesCacheRef, decodedValues);
+
+  useUpdateRefIfShallowNew(decodedValuesCacheRef, decodedValues, (a, b) =>
+    shallowEqualMap(a, b, paramConfigMap)
+  );
 
   // create a setter for updating multiple query params at once
   const setQuery = React.useCallback(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,10 +5276,10 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-serialize-query-params@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.1.0.tgz#b95a15bf0dd4a4df6162c4d72208f1a31e850459"
-  integrity sha512-CF/iHtjCDSj2FzBCsb8JBFruqERpCGgI+8L+236BxhZUwDclwxiOBELvP87HH5EbL9XElvvP+259mP0XgT6l5g==
+serialize-query-params@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.2.0.tgz#12842a42881ad65c1c257e786f7bb00f2fbb2d10"
+  integrity sha512-rkcZFpQjGAA1tTncuon/CyBa81pTMztz0rxspHEnVlTfW+UQNa1rtgfl0PlL6b2Gwp5T1HyIZKyc1xwhZjYUHQ==
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Resolves #100 by supporting a new optional `equals` function on parameters