### PR TITLE
Fix #121 unnecessary updates to setter function reference values

### DIFF
--- a/src/__tests__/useQueryParam-test.tsx
+++ b/src/__tests__/useQueryParam-test.tsx
@@ -103,6 +103,20 @@ describe('useQueryParam', () => {
     expect(setter).toBe(setter2);
   });
 
+  it('does not generate a new setter with each new parameter type', () => {
+    const { wrapper } = setupWrapper({ foo: '123' });
+    const { result, rerender } = renderHook(
+      () => useQueryParam('foo', { ...NumberParam }),
+      {
+        wrapper,
+      }
+    );
+    const [, setter] = result.current;
+    rerender();
+    const [, setter2] = result.current;
+    expect(setter).toBe(setter2);
+  });
+
   it('sets distinct params in the same render', () => {
     const { wrapper } = setupWrapper({
       foo: '1',
@@ -155,11 +169,11 @@ describe('useQueryParam', () => {
 
   it('works with functional JsonParam updates', () => {
     type ParamType = {a: number, b: string};
-    const { wrapper, history, location } = setupWrapper({
+    const { wrapper, history } = setupWrapper({
       foo: '{"a":1,"b":"abc"}',
       bar: 'xxx',
     });
-    const { result, rerender } = renderHook(
+    const { result } = renderHook(
       () => useQueryParam('foo', JsonParam),
       {
         wrapper,

--- a/src/__tests__/useQueryParams-test.tsx
+++ b/src/__tests__/useQueryParams-test.tsx
@@ -7,7 +7,7 @@ import {
   EncodedQuery,
   NumericArrayParam,
   DateParam,
-  JsonParam
+  JsonParam,
 } from 'serialize-query-params';
 
 import { useQueryParams, QueryParamProvider } from '../index';
@@ -102,6 +102,20 @@ describe('useQueryParams', () => {
     const [, setter] = result.current;
 
     setter({ foo: 999 }, 'push');
+    rerender();
+    const [, setter2] = result.current;
+    expect(setter).toBe(setter2);
+  });
+
+  it('does not generate a new setter with each new parameter type', () => {
+    const { wrapper } = setupWrapper({ foo: '123' });
+    const { result, rerender } = renderHook(
+      () => useQueryParams({ foo: { ...NumberParam } }),
+      {
+        wrapper,
+      }
+    );
+    const [, setter] = result.current;
     rerender();
     const [, setter2] = result.current;
     expect(setter).toBe(setter2);
@@ -264,11 +278,11 @@ describe('useQueryParams', () => {
   });
 
   it('works with functional JsonParam updates', () => {
-    const { wrapper, history, location } = setupWrapper({
+    const { wrapper, history } = setupWrapper({
       foo: '{"a":1,"b":"abc"}',
       bar: 'xxx',
     });
-    const { result, rerender } = renderHook(
+    const { result } = renderHook(
       () => useQueryParams({ foo: JsonParam, bar: StringParam }),
       {
         wrapper,


### PR DESCRIPTION
Resolves #121, also goes a little beyond the initial scope to avoid setter function updates for any reason.

I bundled the deps in a "deps" object to avoid the alternatives of having shadowed variable names, having to think about what to rename them individually, or having to move the setter function code somewhere else. It's not the prettiest so I'm happy to choose a different approach if you'd prefer 🙂 