### PR TITLE
Add check for missing QueryParamProvider, update serialize-query-params for query-string version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "serialize-query-params": "^1.2.1"
+    "serialize-query-params": "^1.2.3"
   },
   "husky": {
     "hooks": {

--- a/src/LocationProvider.tsx
+++ b/src/LocationProvider.tsx
@@ -17,15 +17,22 @@ type LocationProviderContext = {
   ) => void;
 };
 
-export const LocationContext = React.createContext<LocationProviderContext>({
+const providerlessContextValue = {
   location: {} as Location,
   getLocation: () => ({} as Location),
   setLocation: () => {},
-});
+};
+
+export const LocationContext = React.createContext<LocationProviderContext>(
+  providerlessContextValue
+);
 
 export function useLocationContext() {
   const context = React.useContext(LocationContext);
-  if (process.env.NODE_ENV === 'development' && context === undefined) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    (context === undefined || context === providerlessContextValue)
+  ) {
     throw new Error('useQueryParams must be used within a QueryParamProvider');
   }
   return context;

--- a/src/__tests__/components-test.tsx
+++ b/src/__tests__/components-test.tsx
@@ -204,3 +204,18 @@ test('date withDefault', () => {
   getByText(/Change/).click();
   expect(queryByText(/x is 2020-06-06/)).toBeTruthy();
 });
+
+test('error when no QueryParamProvider is used', async () => {
+  const history = createMemoryHistory({ initialEntries: ['?x=3'] });
+
+  // silence the react console.error call
+  let errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+  expect(() =>
+    render(
+      <Router history={history}>
+        <QueryParamExample />
+      </Router>
+    )
+  ).toThrow('useQueryParams must be used within a QueryParamProvider');
+  errMock.mockRestore();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5283,10 +5283,10 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-serialize-query-params@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.2.1.tgz#b849d0c004fb6958eabae114e24eb55aa8a50429"
-  integrity sha512-dycN0Cx4cXXIc3E3IaejBHlFWRRO0m/CzIkS41MhjQLwuvRobY1LHgdzPAfUj9sFeSnCmlMQM7iwVdyuhz2PIQ==
+serialize-query-params@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.2.3.tgz#0d6728c2378fa692233af80f4a72765db06f1069"
+  integrity sha512-pTssDTpnDR2p54q1/V1LpG/czg29iX9imxfKF1cupl30BWcRg8R8y3ddB4iHuhuVBO+HjSNj4+tAT1s075iimw==
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Resolves #103 by correctly checking if the provider is missing
- Resolves #127 by updating serialize-query-params to use the latest version which throws an exception in dev if the installed version of query-string is invalid.