### PR TITLE
Adapt for react router

### DIFF
--- a/src/QueryParamProvider.tsx
+++ b/src/QueryParamProvider.tsx
@@ -44,7 +44,6 @@ function adaptWindowHistory(history: History): PushReplaceHistory {
   return adaptedWindowHistory;
 }
 
-
 // we use a lazy caching solution to prevent #46 from happening
 let cachedReactRouterHistory: PushReplaceHistory | undefined;
 let cachedAdaptedReactRouterHistory: PushReplaceHistory | undefined;
@@ -55,8 +54,13 @@ let cachedAdaptedReactRouterHistory: PushReplaceHistory | undefined;
  *
  * @param history history provided by react router
  */
-function adaptReactRouterHistory(history: PushReplaceHistory): PushReplaceHistory {
-  if (history === cachedReactRouterHistory && cachedAdaptedReactRouterHistory != null) {
+function adaptReactRouterHistory(
+  history: PushReplaceHistory
+): PushReplaceHistory {
+  if (
+    history === cachedReactRouterHistory &&
+    cachedAdaptedReactRouterHistory != null
+  ) {
     return cachedAdaptedReactRouterHistory;
   }
 
@@ -70,7 +74,7 @@ function adaptReactRouterHistory(history: PushReplaceHistory): PushReplaceHistor
       history.push(location);
     },
     get location() {
-      return window.location;
+      return history.location;
     },
   };
 
@@ -223,7 +227,7 @@ export function QueryParamProvider({
               stringifyOptions={stringifyOptionsCached}
               {...getLocationProps({
                 ...routeProps,
-                history: adaptReactRouterHistory(routeProps.history)
+                history: adaptReactRouterHistory(routeProps.history),
               })}
             >
               {children}


### PR DESCRIPTION
https://github.com/onumossn/serialize-query-params/blob/master/src/updateLocation.ts#L77 breaks routing for react router as query is not kept in sync with the url, so if a link is used to change the query and then a pushIn query is set using a setter provided by this library, many of the params will revert to the last time a set call was made.