### PR TITLE
Add ArrayEnum params and serialiser 

### DIFF
--- a/packages/serialize-query-params/README.md
+++ b/packages/serialize-query-params/README.md
@@ -79,6 +79,20 @@ import { createEnumParam } from 'serialize-query-params';
 const SortOrderEnumParam = createEnumParam(['asc', 'desc'])
 ```
 
+**Array Enum Param**
+
+You can define array enum param using `createEnumArrayParam`. It will restricts decoded output to a list of allowed values: 
+
+```js
+import { createEnumArrayParam } from 'serialize-query-params';
+
+// feel free to use Enum instead of union types
+type Color = 'red' | 'green' | 'blue'
+
+// values other than 'red', 'green' or 'blue' will be decoded as undefined
+const ColorArrayEnumParam = createEnumArrayParam<Color[]>(['red', 'green', 'blue'])
+```
+
 **Setting a default value**
 
 If you'd like to have a default value, you can wrap your param with `withDefault()`:

--- a/packages/serialize-query-params/src/__tests__/params-test.ts
+++ b/packages/serialize-query-params/src/__tests__/params-test.ts
@@ -12,6 +12,7 @@ import {
   DelimitedArrayParam,
   DelimitedNumericArrayParam,
   createEnumParam,
+  createEnumArrayParam,
 } from '../index';
 
 describe('params', () => {
@@ -116,6 +117,26 @@ describe('params', () => {
       expect(TestEnumParam.encode('foo')).toBe('foo');
       expect(TestEnumParam.decode('bar')).toBe('bar');
       expect(TestEnumParam.decode('baz')).toBeUndefined();
+    });
+    it('createEnumArrayParam', () => {
+      type Color = 'red' | 'green' | 'blue';
+      const TestArrayEnumParam = createEnumArrayParam<Color[]>([
+        'red',
+        'green',
+        'blue',
+      ]);
+
+      expect(TestArrayEnumParam.encode(['red'])).toBe('red');
+      expect(TestArrayEnumParam.encode(['red', 'green', 'blue'])).toBe(
+        'red_green_blue'
+      );
+      expect(TestArrayEnumParam.decode('red_green_blue')).toEqual([
+        'red',
+        'green',
+        'blue',
+      ]);
+      expect(TestArrayEnumParam.decode('red_purple')).toBeUndefined();
+      expect(TestArrayEnumParam.decode('purple')).toBeUndefined();
     });
   });
 });

--- a/packages/serialize-query-params/src/__tests__/serialize-test.ts
+++ b/packages/serialize-query-params/src/__tests__/serialize-test.ts
@@ -8,6 +8,7 @@ import {
   encodeString,
   decodeString,
   decodeEnum,
+  decodeArrayEnum,
   encodeJson,
   decodeJson,
   encodeArray,
@@ -164,6 +165,35 @@ describe('serialize', () => {
       expect(decodeEnum(['foo', 'bar'], enumValues)).toBe('foo');
     });
   })
+
+  describe('decodeArrayEnum', () => {
+    type Color = 'red' | 'green' | 'blue';
+    const enumValues: Color[] = ['red', 'green', 'blue'];
+
+    it('produces the correct value', () => {
+      expect(decodeArrayEnum('red', enumValues)).toEqual(['red']);
+      expect(decodeArrayEnum('red_green_blue', enumValues)).toEqual([
+        'red',
+        'green',
+        'blue',
+      ]);
+      expect(decodeArrayEnum('red,green', enumValues, ',')).toEqual([
+        'red',
+        'green',
+      ]);
+      expect(decodeArrayEnum('red_purple', enumValues)).toBeUndefined();
+      expect(decodeArrayEnum('pink_purple', enumValues)).toBeUndefined();
+      expect(decodeArrayEnum('', enumValues)).toBeUndefined();
+      expect(decodeArrayEnum(undefined, enumValues)).toBeUndefined();
+      expect(decodeArrayEnum(null, enumValues)).toBeNull();
+    });
+
+    it('handles array of values', () => {
+      expect(decodeArrayEnum(['red', 'green'], enumValues)).toEqual(['red']);
+      expect(decodeArrayEnum(['purple'], enumValues)).toBeUndefined();
+      expect(decodeArrayEnum([], enumValues)).toBeNull();
+    });
+  });
 
   describe('encodeJson', () => {
     it('produces the correct value', () => {

--- a/packages/serialize-query-params/src/index.ts
+++ b/packages/serialize-query-params/src/index.ts
@@ -10,6 +10,7 @@ export {
   encodeString,
   decodeString,
   decodeEnum,
+  decodeArrayEnum,
   encodeJson,
   decodeJson,
   encodeArray,
@@ -40,6 +41,7 @@ export {
   DelimitedArrayParam,
   DelimitedNumericArrayParam,
   createEnumParam,
+  createEnumArrayParam,
 } from './params';
 
 export {

--- a/packages/serialize-query-params/src/params.ts
+++ b/packages/serialize-query-params/src/params.ts
@@ -23,6 +23,22 @@ export const createEnumParam = <T extends string>(
 })
 
 /**
+ * Array enum
+ */
+export const createEnumArrayParam = <T extends string[]>(
+  enumValues: T,
+  entrySeparator = '_'
+): QueryParamConfig<T | null | undefined, T | null | undefined> => ({
+  encode: text => {
+    if (text === undefined || text === null || Array.isArray(text))
+      return Serialize.encodeDelimitedArray(text)
+    return Serialize.encodeDelimitedArray([text])
+  },
+  decode: input =>
+    Serialize.decodeArrayEnum(input, enumValues, entrySeparator),
+})
+
+/**
  * Numbers (integers or floats)
  */
 export const NumberParam: QueryParamConfig<

--- a/packages/serialize-query-params/src/serialize.ts
+++ b/packages/serialize-query-params/src/serialize.ts
@@ -272,6 +272,27 @@ export function decodeEnum<T extends string>(
 }
 
 /**
+ * Decodes an enum value from arrays while safely handling null and undefined values.
+ *
+ * @template T
+ * @param {String} input the encoded string
+ * @param {T} enumValues allowed enum values
+ * @param entrySeparator The array as a string with elements joined by the
+ * entry separator
+ * @return {T} the string value from enumValues
+ */
+export function decodeArrayEnum<T extends string[]>(
+  input: string | (string | null)[] | null | undefined,
+  enumValues: T,
+  entrySeparator = '_'
+): T | null | undefined {
+  const str = decodeDelimitedArray(input, entrySeparator)
+  if (str == null) return str
+  if (Array.isArray(str) && str.length === 0) return undefined
+  return str.every((s) => s && enumValues.includes(s)) ? str as T : undefined
+}
+
+/**
  * Encodes anything as a JSON string.
  *
  * @param {Any} any The thing to be encoded


### PR DESCRIPTION
In this PR:
- Add `ArrayEnum` param
- Add `ArrayEnum` serialiser

---

I had the same need for this issue #174, so I've decided to implement a custom version for my application, but I thought of giving it a shot and proposing this change in the package, maybe that would help someone 😉 

This is a very raw implementation, but it should work for simple scenarios.

Here is my scenario as an example

```tsx
type Color = "red" | "green" | "blue";

type FormData = {
  name?: string | null;
  color?: Color[] | null;
};

const Home: NextPageWithAuth = () => {
  const [query, setQuery] = useQueryParams({
    name: StringParam,
    // I know I can use Enums, but I like using union types better, as they don't actually generate code
    color: createEnumArrayParam<Color[]>(["red", "green", "blue"]),
  });

  const { register, handleSubmit, control } = useForm<FormData>({
    defaultValues: query,
  });

  // plain `string` type can't be sent, since I'm relying on prisma, so I need an actual type `Color` coming from query params
  const productQuery = trpc.useQuery(["product.list", { ...query }]);

  // .....
}
```

---

closes #174