### PR TITLE
fix: be more defensive about reading updateType

### DIFF
--- a/packages/use-query-params/src/updateSearchString.ts
+++ b/packages/use-query-params/src/updateSearchString.ts
@@ -121,7 +121,9 @@ export function updateSearchString({
   };
 
   if (navigate) {
-    if (updateType?.startsWith('replace')) {
+    // be defensive about checking updateType since it is somewhat easy to
+    // accidentally pass a second argument to the setter.
+    if (typeof updateType === 'string' && updateType.startsWith('replace')) {
       adapter.replace(newLocation);
     } else {
       adapter.push(newLocation);


### PR DESCRIPTION
Sometimes you may want to pass the setter from useQueryParams to some kind of event handler which supplies more args than necessary. e.g. `onClick={(value, otherStuff) => setQueryParam(value)}` but you instead do `onClick={setQueryParam}`. The setter will interpret that second argument as the updateType which could cause problems. Really, this is a problem in the user code, but in v1 this wasn't a problem, so I'm putting in a defensive check to ensure updateType is a string before calling `startsWith` on it.