### PR TITLE
fix: create package.json for adapters #224

### DIFF
--- a/packages/use-query-params/scripts/copy-adapters.js
+++ b/packages/use-query-params/scripts/copy-adapters.js
@@ -41,4 +41,17 @@ for (const adapterDir of adapterDirs) {
       );
     }
   }
+
+  // create a package.json for import
+  // see #224 https://github.com/pbeshai/use-query-params/issues/224
+  const packageJson = {
+    main: 'index.cjs.js',
+    module: 'index.js',
+    name: `use-query-params/adapters/${adapterName}`,
+    types: 'index.d.ts',
+  };
+  fs.writeFileSync(
+    path.resolve(adapterOutDir, 'package.json'),
+    JSON.stringify(packageJson, null, 2)
+  );
 }


### PR DESCRIPTION
Fixes #224 by generating a package.json for the adapters so tooling can choose between cjs and mjs. Typically I'd expect package-bundler to do this for us, but I think that due to the differing dependency requirements with the same name (E.g. react-router 5 and react-router 6), we can't follow the normal means of things.