### PR TITLE
feat: skip unnecessary updates by default #234

### DIFF
--- a/packages/use-query-params/src/__tests__/routers/shared.tsx
+++ b/packages/use-query-params/src/__tests__/routers/shared.tsx
@@ -470,8 +470,7 @@ export function testSpec(renderWithRouter: any) {
       };
       const { queryByText, getByText } = renderWithRouter(
         <TestComponent />,
-        '?foo=foo1',
-        { enableBatching: true }
+        '?foo=foo1'
       );
 
       expect(queryByText(/{"foo":"foo1"}/)).toBeTruthy();

--- a/packages/use-query-params/src/__tests__/routers/shared.tsx
+++ b/packages/use-query-params/src/__tests__/routers/shared.tsx
@@ -448,5 +448,36 @@ export function testSpec(renderWithRouter: any) {
       );
       expect(numRenders).toBe(2);
     });
+
+    it('doesnt update when the search string is the same', async () => {
+      let numRenders = 0;
+      const TestComponent = () => {
+        const [foo, setFoo] = useQueryParam('foo');
+
+        numRenders += 1;
+        return (
+          <div>
+            {JSON.stringify({ foo })}
+            <button
+              onClick={() => {
+                setFoo('foo1');
+              }}
+            >
+              Change
+            </button>
+          </div>
+        );
+      };
+      const { queryByText, getByText } = renderWithRouter(
+        <TestComponent />,
+        '?foo=foo1',
+        { enableBatching: true }
+      );
+
+      expect(queryByText(/{"foo":"foo1"}/)).toBeTruthy();
+      getByText(/Change/).click();
+      await waitFor(() => expect(queryByText(/{"foo":"foo1"}/)).toBeTruthy());
+      expect(numRenders).toBe(1);
+    });
   });
 }

--- a/packages/use-query-params/src/options.ts
+++ b/packages/use-query-params/src/options.ts
@@ -14,6 +14,7 @@ export const defaultOptions: QueryParamOptionsWithRequired = {
   includeAllParams: false,
   removeDefaultsFromUrl: false,
   enableBatching: false,
+  skipUpdateWhenNoChange: true,
 };
 
 export interface QueryParamOptions {
@@ -22,6 +23,8 @@ export interface QueryParamOptions {
   updateType?: UrlUpdateType;
   includeKnownParams?: boolean;
   includeAllParams?: boolean;
+  /** whether sets that result in no change to the location search string should be ignored (default: true) */
+  skipUpdateWhenNoChange?: boolean;
   params?: QueryParamConfigMap;
 
   /** when a value equals its default, do not encode it in the URL when updating */

--- a/packages/use-query-params/src/updateSearchString.ts
+++ b/packages/use-query-params/src/updateSearchString.ts
@@ -155,6 +155,7 @@ export function enqueueUpdate(
     scheduleTask(() => {
       const updates = updateQueue.slice();
       updateQueue.length = 0;
+      const initialSearchString = updates[0].currentSearchString;
 
       let searchString: string | undefined;
       for (let i = 0; i < updates.length; ++i) {
@@ -163,6 +164,14 @@ export function enqueueUpdate(
             ? updates[i]
             : { ...updates[i], currentSearchString: searchString! };
         searchString = getUpdatedSearchString(modifiedUpdate);
+      }
+
+      // do not update unnecessarily #234
+      if (
+        args.options.skipUpdateWhenNoChange &&
+        searchString === initialSearchString
+      ) {
+        return;
       }
 
       updateSearchString({


### PR DESCRIPTION
By default, do not push and entries into the history stack if the search string is the same. This can be disabled by setting the new option `skipUpdateWhenNoChange` to false. Resolves #234