### PR TITLE
Changed inports to react-router-dom instead of react-router

### DIFF
--- a/packages/use-query-params-adapter-react-router-6/src/index.ts
+++ b/packages/use-query-params-adapter-react-router-6/src/index.ts
@@ -1,6 +1,5 @@
 import { useContext } from 'react';
-import { useNavigate, useLocation } from 'react-router';
-import { UNSAFE_NavigationContext } from 'react-router-dom';
+import { UNSAFE_NavigationContext, useNavigate, useLocation } from 'react-router-dom';
 import {
   QueryParamAdapter,
   QueryParamAdapterComponent,


### PR DESCRIPTION
I had an error with the `ReactRouter6Adapter` that kept telling me that the `useNavigate()` should be used inside a `<Router> context`.
I copied the Adapter to my project, changed the import from `react-router` to `react-router-dom`, and it started working again.
Leaving the PR in case it solves the same problem to someone else (and because we shouldn't be importing from `react-router` directly anyway).