### PR TITLE
fix: specify peerDependencies for adapters compatibility

### DIFF
--- a/packages/use-query-params/package.json
+++ b/packages/use-query-params/package.json
@@ -68,8 +68,18 @@
     "react-router-dom-6": "npm:react-router-dom@^6.8.1"
   },
   "peerDependencies": {
+    "@reach/router": "^1.2.1",
     "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react-dom": ">=16.8.0",
+    "react-router-dom": ">=5"
+  },
+  "peerDependenciesMeta": {
+    "@reach/router": {
+      "optional": true
+    },
+    "react-router-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "serialize-query-params": "^2.0.2"


### PR DESCRIPTION
This PR should fix https://github.com/pbeshai/use-query-params/issues/256

Despite this repo setup, all packages are published as a single `npm` package. Sub-packages have their `package.json` stripped to the simplest form.

This setup is causing some bundlers to not be able to pick up `peerDependencies` for `adapters` and in turn failing the build.  
It might also be caused by `pnpm` `node_modules` linking strategy.

Personally i have encountered the error by using `pnpm` and `vite` together.

By adding `peerDependencies` to the main `package.json` we are ensuring that those dependencies would be properly linked when installing packages.